### PR TITLE
Fix `NullPointerException` on first deployer placed (Fabric/Forge)

### DIFF
--- a/modules/fabric/create/src/main/java/lol/bai/megane/module/create/provider/DeployerProvider.java
+++ b/modules/fabric/create/src/main/java/lol/bai/megane/module/create/provider/DeployerProvider.java
@@ -11,8 +11,13 @@ public class DeployerProvider implements IDataProvider<DeployerBlockEntity> {
 
     @Override
     public void appendData(IDataWriter data, IServerAccessor<DeployerBlockEntity> accessor, IPluginConfig config) {
-        data.add(ItemData.class, res -> res.add(ItemData.of(config)
-            .add(accessor.getTarget().getPlayer().getMainHandItem())));
+        data.add(ItemData.class, res -> {
+            var fakePlayer = accessor.getTarget().getPlayer();
+            if (fakePlayer == null)
+                return;
+
+            res.add(ItemData.of(config).add(fakePlayer.getMainHandItem()));
+        });
     }
 
 }

--- a/modules/forge/create/src/main/java/lol/bai/megane/module/create/provider/DeployerProvider.java
+++ b/modules/forge/create/src/main/java/lol/bai/megane/module/create/provider/DeployerProvider.java
@@ -11,8 +11,13 @@ public class DeployerProvider implements IDataProvider<DeployerBlockEntity> {
 
     @Override
     public void appendData(IDataWriter data, IServerAccessor<DeployerBlockEntity> accessor, IPluginConfig config) {
-        data.add(ItemData.class, res -> res.add(ItemData.of(config)
-            .add(accessor.getTarget().getPlayer().getMainHandItem())));
+        data.add(ItemData.class, res -> {
+            var fakePlayer = accessor.getTarget().getPlayer();
+            if (fakePlayer == null)
+                return;
+
+            res.add(ItemData.of(config).add(fakePlayer.getMainHandItem()));
+        });
     }
 
 }


### PR DESCRIPTION
Fixes #74 #76

There's a brief moment where `getPlayer()` can return `null`.
Sorry had to recreate this PR. I messed up something on the previous PR that caused GitHub to think it is up to date and closed it automatically.